### PR TITLE
Pin Python version to <3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["batch", "cloud", "google", "platform", "gcp"]
 dynamic = ["dependencies"]
-requires-python = ">=3.9, <=3.14"
+requires-python = ">=3.9, <3.15"
 
 [tool.setuptools]
 # Let auto-discovery do its thing with src-layout.


### PR DESCRIPTION
Updated requires-python requirement in pyproject.toml to pin Python versions to <3.15. Re-installed the package in editable mode and verified that all unit tests pass.

---
*PR created automatically by Jules for task [15684692880781854706](https://jules.google.com/task/15684692880781854706) started by @dchaley*