### PR TITLE
Add manual GitHub Actions workflow to release and publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release & Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Build, Publish, and Release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gbatchkit
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+
+    - name: Build package distributions
+      run: python -m build
+
+    - name: Extract package version
+      id: extract_version
+      run: |
+        VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Create and Publish GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: "v${{ env.VERSION }}"
+        name: "v${{ env.VERSION }}"
+        generate_release_notes: true
+        files: |
+          dist/*


### PR DESCRIPTION
This PR introduces a manually triggered GitHub Actions workflow (`.github/workflows/release.yml`) that automates the release and publishing process.

When triggered via `workflow_dispatch`:
1. It checks out the code and sets up Python 3.11.
2. It installs PEP 517 build dependencies and builds the package distributions.
3. It extracts the version from `pyproject.toml` using `tomllib`.
4. It publishes the distributions to PyPI via OIDC (Trusted Publishing).
5. It generates a GitHub release with automatic release notes and uploads the distribution assets.

---
*PR created automatically by Jules for task [12059099441287507679](https://jules.google.com/task/12059099441287507679) started by @dchaley*