### PR TITLE
Split Publish Workflow into Build and Publish Workflows for PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,22 @@
-name: Release & Publish to PyPI
+name: Build Package
 
 on:
-  workflow_dispatch:
-
-permissions:
-  contents: write
-  id-token: write
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_call:
+    outputs:
+      version:
+        description: "The package version"
+        value: ${{ jobs.build.outputs.version }}
 
 jobs:
-  release:
-    name: Build, Publish, and Release
+  build:
+    name: Build package distributions
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/gbatchkit
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
 
     steps:
     - name: Checkout repository
@@ -36,17 +39,10 @@ jobs:
       id: extract_version
       run: |
         VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-
-    - name: Create and Publish GitHub Release
-      uses: softprops/action-gh-release@v2
+    - name: Upload built distributions
+      uses: actions/upload-artifact@v4
       with:
-        tag_name: "v${{ env.VERSION }}"
-        name: "v${{ env.VERSION }}"
-        generate_release_notes: true
-        files: |
-          dist/*
+        name: python-package-distributions
+        path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Release & Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build package
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    name: Publish and Release
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gbatchkit
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download built distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Create and Publish GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: "v${{ needs.build.outputs.version }}"
+        name: "v${{ needs.build.outputs.version }}"
+        generate_release_notes: true
+        files: |
+          dist/*


### PR DESCRIPTION
This pull request splits the release workflow into separate build and publish workflows to adhere to GitHub Actions and PyPI Trusted Publishing best practices.

1. **Build Workflow (`.github/workflows/build.yml`)**: Builds Python package distributions and uploads them as an artifact, without any publishing privileges. It can be triggered on push/PR/workflow_call.
2. **Publish Workflow (`.github/workflows/publish.yml`)**: Manually triggered (`workflow_dispatch`). It calls the build workflow, downloads the artifact, and publishes it using trusted publishing. It also creates a GitHub Release.
3. Removed deprecated `release.yml`.

---
*PR created automatically by Jules for task [17394102448070497916](https://jules.google.com/task/17394102448070497916) started by @dchaley*