### PR TITLE
Modernize license declaration to follow PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,9 +8,9 @@ version = "1.0-alpha7"
 description = "Toolkit for running Google Cloud Batch jobs"
 readme = "README.md"
 authors = [{ name = "David Haley", email = "dchaley@gmail.com" }]
-license = { file = "LICENSE" }
+license = "BSL-1.0"
+license-files = ["LICENSE"]
 classifiers = [
-    "License :: OSI Approved :: Boost Software License 1.0 (BSL-1.0)",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This change modernizes the license declaration in pyproject.toml following PEP 639 and PEP 621. This completely removes the SetuptoolsDeprecationWarning warnings observed during python -m build.

---
*PR created automatically by Jules for task [3899770392848582924](https://jules.google.com/task/3899770392848582924) started by @dchaley*