### PR TITLE
Validate attached disk mount path is located in /mnt/disks/

### DIFF
--- a/src/gbatchkit/jobs.py
+++ b/src/gbatchkit/jobs.py
@@ -252,6 +252,9 @@ def apply_cloud_log_policy(job: dict) -> None:
     }
 
 
+import posixpath
+from pathlib import PurePosixPath
+
 def add_tmp_dir(
     job: dict,
     tmp_dir: str,
@@ -260,6 +263,16 @@ def add_tmp_dir(
     """
     Add a temporary directory to the job definition.
     """
+    # Validation for attached disks being mounted as volumes located in /mnt/disks/
+    # Raises ValueError if tmp_dir is outside /mnt/disks or is not a single name (no subdirectories).
+    normalized_path = posixpath.normpath(tmp_dir)
+    parts = PurePosixPath(normalized_path).parts
+
+    if len(parts) != 4 or parts[0] != "/" or parts[1] != "mnt" or parts[2] != "disks":
+        raise ValueError(
+            "tmp_dir must be located in /mnt/disks/ and consist of a single name (e.g., /mnt/disks/workspace)."
+        )
+
     volume_name = "job-workspace"
     add_attached_disk(job, volume_name, tmp_dir_size_gb)
     add_job_storage_volume(job, tmp_dir, volume_name)

--- a/tests/gbatchkit/jobs_test.py
+++ b/tests/gbatchkit/jobs_test.py
@@ -196,7 +196,7 @@ def test_create_standard_job():
                 commands=["arg1-2", "arg2-2"],
             ),
         ],
-        tmp_dir="/tmp-workspace",
+        tmp_dir="/mnt/disks/tmp-workspace",
         tmp_dir_size_gb=321,
         network_interface=NetworkInterfaceConfig(
             network="projects/my-project/global/networks/my-network",
@@ -221,7 +221,7 @@ def test_create_standard_job():
                         }
                     ],
                     "environment": {
-                        "variables": {"TMPDIR": "/tmp-workspace"},
+                        "variables": {"TMPDIR": "/mnt/disks/tmp-workspace"},
                     },
                     "runnables": [
                         {
@@ -242,7 +242,7 @@ def test_create_standard_job():
                     "volumes": [
                         {
                             "deviceName": "job-workspace",
-                            "mountPath": "/tmp-workspace",
+                            "mountPath": "/mnt/disks/tmp-workspace",
                         }
                     ],
                 },
@@ -348,3 +348,63 @@ def test_add_dependency():
             }
         }
     ]
+
+
+import pytest
+from gbatchkit.jobs import add_tmp_dir
+
+def test_add_tmp_dir_validation_success():
+    # Valid single name inside /mnt/disks
+    job = {
+        "allocationPolicy": {
+            "instances": [
+                {
+                    "policy": {}
+                }
+            ]
+        },
+        "taskGroups": [
+            {
+                "taskSpec": {}
+            }
+        ]
+    }
+    # No error should be raised for valid inputs
+    add_tmp_dir(job, "/mnt/disks/workspace", 10)
+    assert job["taskGroups"][0]["taskSpec"]["volumes"][0]["mountPath"] == "/mnt/disks/workspace"
+
+    # With a trailing slash (which normalizes to /mnt/disks/workspace)
+    add_tmp_dir(job, "/mnt/disks/workspace/", 10)
+
+
+@pytest.mark.parametrize(
+    "invalid_tmp_dir",
+    [
+        "/mnt/disks",                    # too short / empty name
+        "/mnt/disks/",                   # too short / empty name after normalization
+        "/mnt/disks/workspace/sub",      # multiple path elements
+        "/mnt/disks/workspace/sub/",     # multiple path elements
+        "/other/mnt/disks/workspace",    # outside /mnt/disks
+        "mnt/disks/workspace",           # relative path
+        "/mnt/disks/..",                 # resolves to /mnt, which is outside /mnt/disks
+        "/mnt/disks/workspace/..",       # resolves to /mnt/disks, which is too short
+        "/mnt/disks/workspace/../..",    # resolves to /mnt, which is outside
+    ]
+)
+def test_add_tmp_dir_validation_failure(invalid_tmp_dir):
+    job = {
+        "allocationPolicy": {
+            "instances": [
+                {
+                    "policy": {}
+                }
+            ]
+        },
+        "taskGroups": [
+            {
+                "taskSpec": {}
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="tmp_dir must be located in /mnt/disks/ and consist of a single name"):
+        add_tmp_dir(job, invalid_tmp_dir, 10)


### PR DESCRIPTION
We implemented validation for the `tmp_dir` parameter in `add_tmp_dir`. It is validated using `posixpath.normpath` and `PurePosixPath` to ensure it is situated directly under `/mnt/disks` and consists of a single name (no subdirectories). If this is not the case, a `ValueError` is raised. Appropriate unit tests have been added to verify this.

---
*PR created automatically by Jules for task [16101192417925619315](https://jules.google.com/task/16101192417925619315) started by @dchaley*