### PR TITLE
Add optional project parameter to submit_job

### DIFF
--- a/src/gbatchkit/jobs.py
+++ b/src/gbatchkit/jobs.py
@@ -1,7 +1,7 @@
 import json
 import subprocess
 import tempfile
-from typing import List, TypeVar, Union
+from typing import List, Optional, TypeVar, Union
 
 import math
 import smart_open
@@ -17,7 +17,9 @@ from gbatchkit.types import (
 TaskArgsType = TypeVar("TaskArgsType")
 
 
-def submit_job(job: dict, job_id: str, region: str) -> None:
+def submit_job(
+    job: dict, job_id: str, region: str, project: Optional[str] = None
+) -> None:
     """
     Submit a job to the Batch service.
     """
@@ -45,6 +47,9 @@ def submit_job(job: dict, job_id: str, region: str) -> None:
             "--config",
             job_json_file.name,
         ]
+        if project:
+            cmd.extend(["--project", project])
+
         result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
         if result.returncode != 0:

--- a/tests/gbatchkit/jobs_test.py
+++ b/tests/gbatchkit/jobs_test.py
@@ -65,6 +65,50 @@ def test_submit_job(mock_smart_open, mock_subprocess_run):
     )
 
 
+@patch("subprocess.run")
+@patch("smart_open.open", new_callable=mock_open)
+def test_submit_job_with_project(mock_smart_open, mock_subprocess_run):
+    job = {
+        "taskGroups": [
+            {
+                "taskSpec": {
+                    "runnables": [
+                        {
+                            "container": {
+                                "image_uri": "test-image",
+                                "entrypoint": "test-command",
+                            }
+                        }
+                    ]
+                },
+                "taskCount": 1,
+            }
+        ]
+    }
+
+    mock_subprocess_run.return_value = CompletedProcess([], returncode=0)
+    submit_job(job, job_id="test-job-id", region="us-central1", project="my-test-project")
+
+    # Verify that subprocess.run was called with --project
+    mock_subprocess_run.assert_called_once_with(
+        [
+            "gcloud",
+            "batch",
+            "jobs",
+            "submit",
+            "test-job-id",
+            "--location",
+            "us-central1",
+            "--config",
+            ANY,
+            "--project",
+            "my-test-project",
+        ],
+        stdout=DEVNULL,
+        stderr=PIPE,
+    )
+
+
 @patch("smart_open.open", new_callable=mock_open)
 def test_prepare_multitask_job_with_single_task_list(mock_smart_open):
     job = {


### PR DESCRIPTION
Added optional `project` parameter (default `None`) to `submit_job`. When specified, `--project <project>` is passed on the command line to `gcloud batch jobs submit`. Updated unit tests to verify behavior.

---
*PR created automatically by Jules for task [6395455828952712314](https://jules.google.com/task/6395455828952712314) started by @dchaley*