### PR TITLE
Use gcloud alpha for batch job dependencies and bump to 1.0-alpha9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gbatchkit"
-version = "1.0-alpha8"
+version = "1.0-alpha9"
 description = "Toolkit for running Google Cloud Batch jobs"
 readme = "README.md"
 authors = [{ name = "David Haley", email = "dchaley@gmail.com" }]

--- a/src/gbatchkit/jobs.py
+++ b/src/gbatchkit/jobs.py
@@ -36,17 +36,21 @@ def submit_job(
             job_json_str = json.dumps(job)
             f.write(job_json_str)
 
-        cmd = [
-            "gcloud",
-            "batch",
-            "jobs",
-            "submit",
-            job_id,
-            "--location",
-            region,
-            "--config",
-            job_json_file.name,
-        ]
+        cmd = ["gcloud"]
+        if job.get("dependencies"):
+            cmd.append("alpha")
+        cmd.extend(
+            [
+                "batch",
+                "jobs",
+                "submit",
+                job_id,
+                "--location",
+                region,
+                "--config",
+                job_json_file.name,
+            ]
+        )
         if project:
             cmd.extend(["--project", project])
 

--- a/tests/gbatchkit/jobs_test.py
+++ b/tests/gbatchkit/jobs_test.py
@@ -67,6 +67,58 @@ def test_submit_job(mock_smart_open, mock_subprocess_run):
 
 @patch("subprocess.run")
 @patch("smart_open.open", new_callable=mock_open)
+def test_submit_job_with_dependencies(mock_smart_open, mock_subprocess_run):
+    job = {
+        "taskGroups": [
+            {
+                "taskSpec": {
+                    "runnables": [
+                        {
+                            "container": {
+                                "image_uri": "test-image",
+                                "entrypoint": "test-command",
+                            }
+                        }
+                    ]
+                },
+                "taskCount": 1,
+            }
+        ],
+        "dependencies": [
+            {
+                "items": {
+                    "job-id-1": "SUCCEEDED",
+                }
+            }
+        ],
+    }
+
+    mock_subprocess_run.return_value = CompletedProcess([], returncode=0)
+    submit_job(job, job_id="test-job-id", region="us-central1", project="my-test-project")
+
+    # Verify that subprocess.run was called with "alpha"
+    mock_subprocess_run.assert_called_once_with(
+        [
+            "gcloud",
+            "alpha",
+            "batch",
+            "jobs",
+            "submit",
+            "test-job-id",
+            "--location",
+            "us-central1",
+            "--config",
+            ANY,
+            "--project",
+            "my-test-project",
+        ],
+        stdout=DEVNULL,
+        stderr=PIPE,
+    )
+
+
+@patch("subprocess.run")
+@patch("smart_open.open", new_callable=mock_open)
 def test_submit_job_with_project(mock_smart_open, mock_subprocess_run):
     job = {
         "taskGroups": [


### PR DESCRIPTION
This change updates gbatchkit to use `gcloud alpha batch jobs submit` when submitting jobs with dependencies and bumps the project version to `1.0-alpha9`.

---
*PR created automatically by Jules for task [2963909888333488352](https://jules.google.com/task/2963909888333488352) started by @dchaley*